### PR TITLE
[Fix] 복권 기회 남아있을 시 다시 긁을 수 있게 수정

### DIFF
--- a/service/src/components/common/Button/Button.tsx
+++ b/service/src/components/common/Button/Button.tsx
@@ -38,7 +38,7 @@ const Button = ({
 
   const buttonStyle: Record<string, string> = {
     square: `px-7 py-2.5 ${isActive ? 'bg-primary' : 'bg-gray-400'}`,
-    squareWithBorder: `px-7 py-[9px] border border-primary`,
+    squareWithBorder: `px-7 py-[9px] border border-primary bg-white`,
     round: `p-2.5 rounded-[10px] ${isActive ? 'bg-primary' : 'bg-gray-400'}`,
     roundDone: `p-2.5 rounded-[10px] bg-white`,
     reaction: `px-2.5 py-2 bg-white rounded-[5px] shadow-20 ${

--- a/service/src/pages/LotteryLounge.tsx
+++ b/service/src/pages/LotteryLounge.tsx
@@ -25,11 +25,18 @@ const LotteryLoungePage = () => {
   const [isScratched, setIsScratched] = useState(false);
   const { setActiveTab } = useTabContext();
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
+  const [remainDrawCount, setRemainDrawCount] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
     setActiveTab('quiz');
   }, []);
+
+  useEffect(() => {
+    if (data?.isSuccess) {
+      setRemainDrawCount(data.result.remainDrawCount);
+    }
+  }, [data]);
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
@@ -68,7 +75,7 @@ const LotteryLoungePage = () => {
           <div className='self-stretch items-center justify-center flex-col flex gap-4 pointer-events-none'>
             <Button
               type='square'
-              text={`내가 초대한 친구 ${data?.result?.invitedNum ?? 0}회 | 오늘의 복권 기회 ${data?.result?.remainDrawCount ?? 0}회`}
+              text={`내가 초대한 친구 ${data?.result?.invitedNum ?? 0}회 | 오늘의 복권 기회 ${remainDrawCount}회`}
               handleClick={sample}
             />
             <div className='text-center'>
@@ -76,7 +83,7 @@ const LotteryLoungePage = () => {
                 복권을 통해 <span className='text-primary'>나의 경품</span>을
                 확인하세요!
               </div>
-              <div className='text-gray-600 text-b-m'>
+              <div className='text-gray-600 text-b-l'>
                 같은 모양이 연달아 3개 나올 시 랜덤으로 경품에 당첨돼요
               </div>
             </div>
@@ -114,7 +121,10 @@ const LotteryLoungePage = () => {
             </div>
             <LotteryCanvas
               onScratch={handleScratchResult}
-              remainDrawCount={data?.result?.remainDrawCount ?? 0}
+              remainDrawCount={remainDrawCount}
+              handleRemainDrawCount={() =>
+                setRemainDrawCount(remainDrawCount - 1)
+              }
             />
           </div>
           <Attendance counts={data?.result?.drawAttendanceCount ?? 0} />

--- a/service/src/utils/confettiCrafter.ts
+++ b/service/src/utils/confettiCrafter.ts
@@ -45,7 +45,7 @@ export const craftFireworks = (duration: number) => {
       return clearInterval(interval);
     }
 
-    const particleCount = 50 * (timeLeft / duration);
+    const particleCount = 500 * (timeLeft / duration);
     confetti({
       ...defaults,
       particleCount,


### PR DESCRIPTION
## 요약
복권 기회 남아있을 시 다시 긁을 수 있게 수정
## 작업 내용
- 복권 기회 0 이상이면 복권 다시 긁기 버튼 활성화
- 0일 경우 메인 화면으로 돌아가기 버튼 활성화
- 컨페티 너무 많이 켜지는 오류 수정

## 관련 이슈
<!--  관련된 이슈를 적어주세요.  -->
close #182


## 첨부 자료 (선택사항)
<img width="952" alt="스크린샷 2024-08-23 오후 5 20 41" src="https://github.com/user-attachments/assets/44190ae9-07de-45f1-be43-51b7cac94f4e">
